### PR TITLE
Columns: honour directional no-indent-* classes

### DIFF
--- a/src/components/layout/columns/columns.astro
+++ b/src/components/layout/columns/columns.astro
@@ -159,23 +159,37 @@ let items = layoutBlocks.length ? layoutBlocks : contentBlocks;
     > :global(section) {
       height: 100%;
 
+      // Per-side so directional no-indent-* classes can drop a single edge.
+      // (A `padding` shorthand here would clobber all four sides at once and
+      // make no-indent-top/bottom/left/right ineffective inside columns.)
       &:not(.no-indent) {
-        padding: calc(var(--column-gap));
+        &:not(.no-indent-top) {
+          padding-top: var(--column-gap);
+        }
+        &:not(.no-indent-bottom) {
+          padding-bottom: var(--column-gap);
+        }
+        &:not(.no-indent-left) {
+          padding-left: var(--column-gap);
+        }
+        &:not(.no-indent-right) {
+          padding-right: var(--column-gap);
+        }
       }
     }
   }
 
   :where(.columns) > {
-    .first-in-row > :global(:where(section:not(.no-indent))) {
+    .first-in-row > :global(:where(section:not(.no-indent):not(.no-indent-left))) {
       padding-left: var(--indent);
     }
-    .last-in-row > :global(:where(section:not(.no-indent))) {
+    .last-in-row > :global(:where(section:not(.no-indent):not(.no-indent-right))) {
       padding-right: var(--indent);
     }
-    .first-in-column > :global(:where(section:not(.no-indent))) {
+    .first-in-column > :global(:where(section:not(.no-indent):not(.no-indent-top))) {
       padding-top: calc(var(--indent) * var(--vertical-indent));
     }
-    .last-in-column > :global(:where(section:not(.no-indent))) {
+    .last-in-column > :global(:where(section:not(.no-indent):not(.no-indent-bottom))) {
       padding-bottom: calc(var(--indent) * var(--vertical-indent));
     }
   }


### PR DESCRIPTION
Inside layout/columns, the no-indent-top/bottom/left/right classes had no effect: the component re-applied its own cell padding via selectors gated only on the all-sides .no-indent, and the base padding was an all-sides shorthand. So a section with e.g. no-indent-top still received top padding, leaving an oversized gap between stacked sections.

(See screenshot example included)

- Split the base cell padding into per-side longhands, each skipped when the matching no-indent-<side> class is present.
- Add the matching directional exclusion to each first/last-in-row/column edge-padding rule.

Sections with no directional class are unaffected (all sides still padded); only sections that opt out of a specific edge change. Submodule fix — benefits all Millstream sites.

<img width="454" height="796" alt="Screenshot 2026-06-04 at 8 16 33 pm" src="https://github.com/user-attachments/assets/9acbeb84-8fb5-449b-9f67-cc2b7eeff784" />
<img width="880" height="1085" alt="Screenshot 2026-06-04 at 8 17 06 pm" src="https://github.com/user-attachments/assets/7f00b40d-9005-4dae-a60b-1cd6616edae1" />
<img width="969" height="779" alt="Screenshot 2026-06-04 at 8 17 19 pm" src="https://github.com/user-attachments/assets/83b0b90a-5fd4-4d43-8515-5e245be61e46" />
