### PR TITLE
Fix reCAPTCHA attribution text rendering at inconsistent sizes

### DIFF
--- a/src/components/form/form.astro
+++ b/src/components/form/form.astro
@@ -142,6 +142,11 @@ const recaptcha = preferences.API.google_recaptcha_v3?.api_key;
   form[data-status] input[type="submit"] {
     display: none;
   }
+
+  .recaptcha-attribution,
+  .recaptcha-attribution a {
+    font-size: var(--text-size-small);
+  }
 </style>
 
 <style is:global>


### PR DESCRIPTION
## Summary
- The reCAPTCHA disclosure `<span>` in `form.astro` wasn't covered by the site-wide type-size rule (`a, p, li, input, button, textarea, label, select`), so its plain text fell back to the browser default font size while the two links inside it were explicitly sized to `--text-size-medium`.
- Adds a scoped rule sizing both the span and its nested links consistently at `--text-size-small`, matching the existing "fine print" pattern used elsewhere (e.g. breadcrumbs).

## Test plan
- [x] Verified via dev server that the scoped CSS rule (`.recaptcha-attribution[data-astro-cid-*], .recaptcha-attribution a[data-astro-cid-*]`) is emitted and applies to the rendered markup on a form page with reCAPTCHA enabled.