### PR TITLE
Fix reCAPTCHA v3 forms failing to submit

### DIFF
--- a/src/components/form/form.astro
+++ b/src/components/form/form.astro
@@ -198,7 +198,9 @@ const recaptcha = preferences.API.google_recaptcha_v3?.api_key;
               action: "submit",
             })
             .then(function (token: string) {
-              form.getElementById("g-recaptcha-response").value = token;
+              form.querySelector<HTMLInputElement>(
+                "#g-recaptcha-response",
+              )!.value = token;
               form.submit();
             });
         });


### PR DESCRIPTION
## Summary
- `initRecaptcha` in `form.astro` called `form.getElementById("g-recaptcha-response")`, but `getElementById` doesn't exist on `HTMLFormElement` (only on `document`/`DocumentFragment`).
- This threw inside the `grecaptcha.execute().then()` callback, so `form.submit()` was never reached — any form with reCAPTCHA v3 enabled hangs forever on the loading spinner and never actually submits.
- Only surfaces once a site configures a `google_recaptcha_v3` API key, since `initRecaptcha` bails out early otherwise — likely affects every client site with reCAPTCHA v3 turned on.
- Fix: use `form.querySelector("#g-recaptcha-response")` instead.

## Test plan
- [x] Confirmed the bug live on bwps.wa.edu.au (minified bundle contained the same `t.getElementById(...)` call, spinner never resolved)
- [ ] Would appreciate a check on another site using reCAPTCHA v3 forms if convenient, but the root cause (calling a document-only method on an element) is unambiguous